### PR TITLE
Add Roles support to TrustHeaderAuthenticator

### DIFF
--- a/modules/ginas/app/ix/ginas/fda/TrustHeaderAuthenticator.java
+++ b/modules/ginas/app/ix/ginas/fda/TrustHeaderAuthenticator.java
@@ -57,7 +57,9 @@ public class TrustHeaderAuthenticator implements Authenticator {
 			UserInfo ui=getUserInfoFromHeaders(r);
 			if (ui.username != null) {
 				UserProfile up = Authentication.setUserProfileSessionUsing(ui.username, ui.email);
-				up.setRoles(ui.roles);
+				if (!ui.roles.isEmpty()) {
+					up.setRoles(ui.roles);
+				}
 				return up;
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
The Roles Header must be a String of Semicolon separated G-SRS Roles without spaces.
This can be useful for SAML based Authentication.