### PR TITLE
Trust header authenticator roles

### DIFF
--- a/modules/ginas/app/ix/ginas/fda/TrustHeaderAuthenticator.java
+++ b/modules/ginas/app/ix/ginas/fda/TrustHeaderAuthenticator.java
@@ -57,7 +57,9 @@ public class TrustHeaderAuthenticator implements Authenticator {
 			UserInfo ui=getUserInfoFromHeaders(r);
 			if (ui.username != null) {
 				UserProfile up = Authentication.setUserProfileSessionUsing(ui.username, ui.email);
-				up.setRoles(ui.roles);
+				if (!ui.roles.isEmpty()) {
+					up.setRoles(ui.roles);
+				}
 				return up;
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
This is a slightly modified version of your pull request in #4 

I moved the splitting of the roles out of the constructor in case we decide to reuse this object in the future in other authentication mechanisms and I moved the split call out to it's own Pattern object so we only compile the Pattern once instead of every request.

If this looks good I can merge it.