### PR TITLE
set upper limit for the range of numbers in CodeSequentialGenerator

### DIFF
--- a/modules/ginas/app/ix/ginas/controllers/v1/CodeFactory.java
+++ b/modules/ginas/app/ix/ginas/controllers/v1/CodeFactory.java
@@ -72,7 +72,7 @@ public class CodeFactory extends EntityFactory {
         return field (uuid, path, finder);
     }
     
-    public static Optional<Tuple<Long,Code>> getHighestValueCode(String codeSystem, String suffix, Number last){
+    public static Optional<Tuple<Long,Code>> getHighestValueCode(String codeSystem, String suffix, Long last){
     	try(Stream<Code> codes=StreamUtil.forIterator(
     				finder.where()
     				.and(com.avaje.ebean.Expr.like("code","%" + suffix), com.avaje.ebean.Expr.eq("codeSystem",codeSystem))
@@ -84,7 +84,7 @@ public class CodeFactory extends EntityFactory {
                         return Tuple.of(new Long(Long.parseLong(cd.code.replace(suffix, ""))),cd);
                     }
                 })
-                .filter(t -> last == null || t.k() <= last.longValue())
+                .filter(t -> last == null || t.k() <= last)
 	    		.max(new Comparator<Tuple<Long,Code>>(){
 
                     public int compare(Tuple<Long,Code> l1, Tuple<Long,Code> l2){

--- a/modules/ginas/app/ix/ginas/controllers/v1/CodeFactory.java
+++ b/modules/ginas/app/ix/ginas/controllers/v1/CodeFactory.java
@@ -72,7 +72,7 @@ public class CodeFactory extends EntityFactory {
         return field (uuid, path, finder);
     }
     
-    public static Optional<Tuple<Long,Code>> getHighestValueCode(String codeSystem, String suffix){
+    public static Optional<Tuple<Long,Code>> getHighestValueCode(String codeSystem, String suffix, Number last){
     	try(Stream<Code> codes=StreamUtil.forIterator(
     				finder.where()
     				.and(com.avaje.ebean.Expr.like("code","%" + suffix), com.avaje.ebean.Expr.eq("codeSystem",codeSystem))
@@ -84,6 +84,7 @@ public class CodeFactory extends EntityFactory {
                         return Tuple.of(new Long(Long.parseLong(cd.code.replace(suffix, ""))),cd);
                     }
                 })
+                .filter(t -> last == null || t.k() <= last.longValue())
 	    		.max(new Comparator<Tuple<Long,Code>>(){
 
                     public int compare(Tuple<Long,Code> l1, Tuple<Long,Code> l2){

--- a/modules/ginas/app/ix/ginas/processors/UniqueCodeGenerator.java
+++ b/modules/ginas/app/ix/ginas/processors/UniqueCodeGenerator.java
@@ -23,10 +23,11 @@ public class UniqueCodeGenerator implements EntityProcessor<Substance> {
 		String name = 				(String)  m.get("name");
 		codeSystem = 				(String)  m.get("codesystem");
         String codeSystemSuffix = 	(String)  m.get("suffix");
+        Number last = 				(Number)  m.get("last");
         int length = 				(Integer) m.get("length");
         boolean padding = 			(Boolean) m.get("padding");
         if(codeSystem!=null){
-        	seqGen=new CodeSequentialGenerator(name, length,codeSystemSuffix,padding,codeSystem);
+        	seqGen=new CodeSequentialGenerator(name, length,codeSystemSuffix,padding,last,codeSystem);
         }
         addCodeSystem();
 	}

--- a/modules/ginas/app/ix/ginas/processors/UniqueCodeGenerator.java
+++ b/modules/ginas/app/ix/ginas/processors/UniqueCodeGenerator.java
@@ -23,7 +23,7 @@ public class UniqueCodeGenerator implements EntityProcessor<Substance> {
 		String name = 				(String)  m.get("name");
 		codeSystem = 				(String)  m.get("codesystem");
         String codeSystemSuffix = 	(String)  m.get("suffix");
-        Number last = 				(Number)  m.get("last");
+        Long last = 				(Long) m.computeIfPresent("last", (key,val)->((Number) val).longValue());
         int length = 				(Integer) m.get("length");
         boolean padding = 			(Boolean) m.get("padding");
         if(codeSystem!=null){

--- a/modules/ginas/app/ix/ginas/utils/CodeSequentialGenerator.java
+++ b/modules/ginas/app/ix/ginas/utils/CodeSequentialGenerator.java
@@ -29,7 +29,7 @@ public class CodeSequentialGenerator extends SequentialNumericIDGenerator<Substa
 								   @JsonProperty("len") int len,
 								   @JsonProperty("suffix") String suffix,
 								   @JsonProperty("padding") boolean padding,
-								   @JsonProperty("last") Number last,
+								   @JsonProperty("last") Long last,
 								   @JsonProperty("codeSystem") String codeSystem) {
 		super(len, suffix, padding);
 		this.name = name;

--- a/modules/ginas/app/ix/ginas/utils/CodeSequentialGenerator.java
+++ b/modules/ginas/app/ix/ginas/utils/CodeSequentialGenerator.java
@@ -29,12 +29,13 @@ public class CodeSequentialGenerator extends SequentialNumericIDGenerator<Substa
 								   @JsonProperty("len") int len,
 								   @JsonProperty("suffix") String suffix,
 								   @JsonProperty("padding") boolean padding,
+								   @JsonProperty("last") Number last,
 								   @JsonProperty("codeSystem") String codeSystem) {
 		super(len, suffix, padding);
 		this.name = name;
 		this.codeSystem=codeSystem;
 		this.lastNum = CachedSupplier.runOnce(()->{
-			Optional<Tuple<Long,Code>> code=CodeFactory.getHighestValueCode(codeSystem, suffix);
+			Optional<Tuple<Long,Code>> code=CodeFactory.getHighestValueCode(codeSystem, suffix, last);
 
 			if(code.isPresent()){
 				return new AtomicLong(code.get().k());


### PR DESCRIPTION
I've added optional 'last' parameter to CodeSequentialGenerator. It can be used to define end of blocks for not continuous range of numbers. (Example: the last block of codes already used for special purpose Substances)