### PR TITLE
HTML representation of ChemicalStructures formula

### DIFF
--- a/app/ix/core/models/Structure.java
+++ b/app/ix/core/models/Structure.java
@@ -184,7 +184,7 @@ public class Structure extends BaseModel implements ForceUpdatableModel{
     @Indexable(name = "Molecular Formula", facet = true)
     public String formula;
 
-    @JsonProperty("_html_formula")
+    @JsonProperty("_formula-html")
     public String htmlFormula() {
         if (formula == null) {
             return "";

--- a/app/ix/core/models/Structure.java
+++ b/app/ix/core/models/Structure.java
@@ -184,6 +184,27 @@ public class Structure extends BaseModel implements ForceUpdatableModel{
     @Indexable(name = "Molecular Formula", facet = true)
     public String formula;
 
+    @JsonProperty("_html_formula")
+    public String htmlFormula() {
+        if (formula == null) {
+            return "";
+        }
+        String HTMLFormula = formula.replaceAll("([a-zA-Z])([0-9]+)", "$1<sub>$2</sub>");
+        if (charge != null && charge != 0 && !HTMLFormula.contains(".")) {
+            String sCharge = Integer.toString(charge);
+            String sSign = "+";
+            if (charge < 0) {
+                sCharge = sCharge.substring(1);
+                sSign = "-";
+            }
+            if ("1".equals(sCharge)) {
+                sCharge = "";
+            }
+            HTMLFormula = HTMLFormula + "<sup>" + sCharge + sSign + "</sup>";
+        }
+        return HTMLFormula;
+    }
+
     @JsonProperty("stereochemistry")
     public void setStereoChemistry(Stereo stereoChemistry) {
         this.stereoChemistry = stereoChemistry;

--- a/modules/ginas/app/ix/ginas/views/details/properties/moieties.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/moieties.scala.html
@@ -22,7 +22,7 @@
 										<span>Molecular Formula</span>
 									</td>
 									<td class="monospace">
-										@m.structure.formula
+										@Html(m.structure.htmlFormula())
 									</td>
 								</tr>
 								

--- a/modules/ginas/app/ix/ginas/views/details/properties/polymermonomers.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/polymermonomers.scala.html
@@ -131,7 +131,7 @@
 @fillTable(s: GinasChemicalStructure, stype: String) = {
 	@if(stype == "structure") {
 	    <tr>
-	        <td>@s.formula</td>
+	        <td>@Html(s.htmlFormula())</td>
 	        <td>@s.mwt</td>
 	        <td><span class="badge">@s.definedStereo / @s.stereoCenters</span></td>
 	        <td><span class="badge">@s.ezCenters</span></td>

--- a/modules/ginas/app/ix/ginas/views/details/properties/polymersrus.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/polymersrus.scala.html
@@ -162,7 +162,7 @@
 @fillTable(s: GinasChemicalStructure, stype: String) = {
 	@if(stype == "structure") {
 	    <tr>
-	        <td>@s.formula</td>
+	        <td>@Html(s.htmlFormula())</td>
 	        <td>@s.mwt</td>
 	        <td><span class="badge">@s.definedStereo / @s.stereoCenters</span></td>
 	        <td><span class="badge">@s.ezCenters</span></td>

--- a/modules/ginas/app/ix/ginas/views/details/properties/polymerstructure.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/polymerstructure.scala.html
@@ -74,7 +74,7 @@
 @fillTable(s: GinasChemicalStructure, stype: String) = {
 	@if(stype == "structure") {
 	    <tr>
-	        <td>@s.formula</td>
+	        <td>@Html(s.htmlFormula())</td>
 	        <td>@s.mwt</td>
 	        <td><span class="badge">@s.definedStereo / @s.stereoCenters</span></td>
 	        <td><span class="badge">@s.ezCenters</span></td>

--- a/modules/ginas/app/ix/ginas/views/details/properties/structure.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/structure.scala.html
@@ -76,7 +76,7 @@
 				
 				<tr>
 					<td><span>Molecular Formula</span></td>
-					<td class="monospace">@sub.structure.formula</td>
+					<td class="monospace">@Html(sub.structure.htmlFormula())</td>
 				</tr>
 				
 				<tr>

--- a/modules/ginas/app/ix/ginas/views/list/chemlist.scala.html
+++ b/modules/ginas/app/ix/ginas/views/list/chemlist.scala.html
@@ -96,7 +96,7 @@
         <h5><strong>Formula:</strong></h5>
     </div>
     <div class = "col-md-8">
-        <h5>@chem.structure.formula</h5>
+        <h5>@Html(chem.structure.htmlFormula())</h5>
     </div>
 </div>
 <div class = "row">


### PR DESCRIPTION
**htmlFormula** function was added to Structure class. Subscript will be used to display number of the Atoms. Superscript will be used to display charge of the Molecule.
Example: H<sub>2</sub>O or OH<sup>-</sup>

**_html_formula** property added to JSON for future use in GSRSFrontend.