### PR TITLE
switch to bintray Typesafe and sbt-plugin repos

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
-resolvers += "Typesafe repository" at "https://repo.typesafe.com/typesafe/releases/"
+resolvers += Resolver.bintrayRepo("typesafe", "maven-releases")
 
-resolvers += Resolver.url("artifactory", url("https://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
-
+resolvers += Resolver.bintrayRepo("sbt", "sbt-plugin-releases")
 
 // The Play plugin
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.3.10")


### PR DESCRIPTION
1. Switch Typesafe repository to bintray, because used URL is already redirected to https://dl.bintray.com/typesafe/maven-releases/
2. Switch sbt-plugin repostitory to bintray, because the artifactory repo no longer available.