### PR TITLE
Dockerize a gsrs-play

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ RUN cd /opt && \
     jar xf /tmp/build/modules/ginas/target/universal/ginas-*.zip && \
     mv /opt/ginas-* /opt/g-srs && \
     chmod 755 /opt/g-srs/bin/ginas
+RUN cd /root && \
+    jar xf /tmp/build/lib/jni-inchi-0.7-jar-with-dependencies.jar && \
+    mkdir -p /root/.jnati/repo/jniinchi/1.03_1 && \
+    mv /root/META-INF/jniinchi/1.03_1/LINUX-AMD64 /root/.jnati/repo/jniinchi/1.03_1/LINUX-AMD64 && \
+    rm -rf * && \
+    rm -rf .ivy2 .sbt && \
+    chmod -R g=u /root
 WORKDIR /opt/g-srs
 RUN mv /tmp/build/modules/ginas/conf /opt/g-srs/conf
 RUN sed -i "s/localhost/db/g" conf/ginas-mysql.conf
@@ -17,6 +24,7 @@ RUN sed -i "s/#evolutionplugin=disabled/evolutionplugin=disabled/g" conf/ginas-*
 FROM centos:8
 RUN dnf -y install dejavu-sans-fonts dejavu-serif-fonts fontconfig java-1.8.0-openjdk-headless && dnf clean all
 COPY --from=builder /opt /opt
+COPY --from=builder /root /root
 COPY entrypoint.sh /entrypoint.sh
 RUN fc-cache -f && \
     mkdir /data && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM centos:8 AS builder
-RUN dnf -y install git java-1.8.0-openjdk-devel
+RUN dnf -y install dejavu-sans-fonts dejavu-serif-fonts fontconfig git java-1.8.0-openjdk-devel && dnf clean all && fc-cache -f
 COPY . /tmp/build
 WORKDIR /tmp/build
 RUN ./activator clean
@@ -14,7 +14,7 @@ RUN sed -i "s/localhost:5433/db:5432/g" conf/ginas-postgres.conf
 RUN sed -i "s/#evolutionplugin=disabled/evolutionplugin=disabled/g" conf/ginas-*.conf
 
 FROM centos:8
-RUN dnf -y install java-1.8.0-openjdk-headless
+RUN dnf -y install dejavu-sans-fonts dejavu-serif-fonts fontconfig java-1.8.0-openjdk-headless && dnf clean all && fc-cache -f
 COPY --from=builder /opt /opt
 COPY entrypoint.sh /entrypoint.sh
 VOLUME ["/opt/g-srs/ginas.ix", "/opt/g-srs/logs", "/opt/g-srs/exports"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 FROM centos:8 AS builder
-RUN curl -o /etc/yum.repos.d/bintray-sbt-rpm.repo https://bintray.com/sbt/rpm/rpm
-RUN dnf -y install git java-1.8.0-openjdk-devel sbt
-RUN mkdir /tmp/build
+RUN dnf -y install git java-1.8.0-openjdk-devel
 COPY . /tmp/build
 WORKDIR /tmp/build
-RUN sbt -Dconfig.file=modules/ginas/conf/ginas.conf ginas/dist
+RUN ./activator clean
+RUN ./activator -Dconfig.file=modules/ginas/conf/ginas.conf ginas/dist
 WORKDIR /opt
-RUN jar xf /tmp/build/modules/ginas/target/universal/ginas-*.zip
-RUN mv /opt/ginas-* /opt/g-srs
+RUN jar xf /tmp/build/modules/ginas/target/universal/ginas-*.zip && mv /opt/ginas-* /opt/g-srs
 WORKDIR /opt/g-srs
 RUN mv /tmp/build/modules/ginas/conf /opt/g-srs/conf
 RUN mkdir -p ginas.ix exports logs conf/sql conf/sql/init conf/sql/load conf/sql/post conf/sql/test conf/evolutions/default

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
     environment:
       GSRS_CACHE_RESET: 'false'
       GSRS_DB_RESET: 'false'
-      JAVA_OPTS: '-Xms4096m -Xmx4096m -XX:ReservedCodeCacheSize=512m -Dpidfile.path=/dev/null -Djnati.dir=/opt/g-srs/ginas.ix/cache/jnati -DapplyEvolutions.default=false -Dconfig.file=/opt/g-srs/conf/ginas-mysql.conf'
+      JAVA_OPTS: '-Xms4096m -Xmx4096m -XX:ReservedCodeCacheSize=512m -Dpidfile.path=/dev/null -DapplyEvolutions.default=false -Dconfig.file=/opt/g-srs/conf/ginas-mysql.conf'
+      HOME: '/root'
   db:
     image: mariadb
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,62 @@
+version: '2.1'
+services:
+  ginas:
+    build: .
+    image: ginas
+    restart: always
+    read_only: true
+    ports:
+      - 9000:9000
+    depends_on:
+      db:
+        condition: service_healthy
+    links:
+      - db
+    volumes:
+      - ginasix:/opt/g-srs/ginas.ix
+      - ginasexports:/opt/g-srs/exports
+    tmpfs:
+      - /tmp
+      - /opt/g-srs/conf/evolutions/default
+    environment:
+      GSRS_CACHE_RESET: 'false'
+      GSRS_DB_RESET: 'false'
+      JAVA_OPTS: '-Xms4096m -Xmx4096m -XX:ReservedCodeCacheSize=512m -Dpidfile.path=/dev/null -Djnati.dir=/opt/g-srs/ginas.ix/cache/jnati -DapplyEvolutions.default=false -Dconfig.file=/opt/g-srs/conf/ginas-mysql.conf'
+  db:
+    image: mariadb
+    restart: always
+    read_only: true
+    volumes:
+      - ginasdb:/var/lib/mysql
+    tmpfs:
+      - /tmp
+      - /run/mysqld
+    healthcheck:
+      test: mysqladmin -u root -ppassword ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: ixginasdev
+#  db:
+#    image: postgres
+#    restart: always
+#    read_only: true
+#    volumes:
+#      - ginasdb:/var/lib/postgresql/data
+#    tmpfs:
+#      - /tmp
+#      - /run/postgresql
+#    healthcheck:
+#      test: pg_isready -U postgres
+#      interval: 10s
+#      timeout: 5s
+#      retries: 5
+#    environment:
+#      POSTGRES_PASSWORD: password
+#      POSTGRES_DB: ginas
+volumes:
+  ginasdb:
+  ginasix:
+  ginasexports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,11 +13,9 @@ services:
     links:
       - db
     volumes:
-      - ginasix:/opt/g-srs/ginas.ix
-      - ginasexports:/opt/g-srs/exports
+      - ginasdata:/data
     tmpfs:
       - /tmp
-      - /opt/g-srs/conf/evolutions/default
     environment:
       GSRS_CACHE_RESET: 'false'
       GSRS_DB_RESET: 'false'
@@ -58,5 +56,4 @@ services:
 #      POSTGRES_DB: ginas
 volumes:
   ginasdb:
-  ginasix:
-  ginasexports:
+  ginasdata:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,23 @@
 #!/bin/sh
+
+for dir_name in conf/evolutions/default conf/sql/init conf/sql/load conf/sql/post conf/sql/test exports ginas.ix logs
+do
+    if [ ! -d /data/$dir_name ]; then
+        mkdir -p /data/$dir_name
+    fi
+done
+
+for dir_name in cache h2 payload sequence structure text
+do
+    if [ -d /data/$dir_name ]; then
+        mv /data/$dir_name /data/ginas.ix/$dir_name
+    fi
+done
+
 if [ "x$GSRS_CACHE_RESET" = "xtrue" -o "x$GSRS_DB_RESET" = "xtrue" ]; then
     echo "rm -rf ginas.ix/*"
 fi
+
 if [ "x$GSRS_DB_RESET" = "xtrue" ]; then
     CONFIG_FILE_OPT=`echo $JAVA_OPTS | grep -o "\-Dconfig.file *= *[^ ]*"`
     if [ "x$CONFIG_FILE_OPT" = "x" ]; then
@@ -9,4 +25,5 @@ if [ "x$GSRS_DB_RESET" = "xtrue" ]; then
     fi
     java -cp "lib/*" $CONFIG_FILE_OPT ix.ginas.utils.Evolution
 fi
+
 exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+if [ "x$GSRS_CACHE_RESET" = "xtrue" -o "x$GSRS_DB_RESET" = "xtrue" ]; then
+    echo "rm -rf ginas.ix/*"
+fi
+if [ "x$GSRS_DB_RESET" = "xtrue" ]; then
+    CONFIG_FILE_OPT=`echo $JAVA_OPTS | grep -o "\-Dconfig.file *= *[^ ]*"`
+    if [ "x$CONFIG_FILE_OPT" = "x" ]; then
+        CONFIG_FILE_OPT="-Dconfig.file=conf/ginas.conf"
+    fi
+    java -cp "lib/*" $CONFIG_FILE_OPT ix.ginas.utils.Evolution
+fi
+exec "$@"


### PR DESCRIPTION
gsrs-play dockerization.

Two stages build is used to create gsrs-play container.

3 gsrs-play directories will be exposed as volumes: 'ginas.ix', 'logs' and 'exports'.

Environment Variables:
JAVA_OPTS - is used to configure ginas startup options.
GSRS_DB_RESET - if set to 'true', then backend database will be initialized.
GSRS_CACHE_RESET - if set to 'true', than 'ginas.ix' directory will be cleaned.

docker-compose.yml file provided as example of simple evaluation environment with MariaDB as backend.
