### PR TITLE
showFullName

### DIFF
--- a/app/ix/ginas/models/converters/FDAStringConverter.java
+++ b/app/ix/ginas/models/converters/FDAStringConverter.java
@@ -45,6 +45,9 @@ public class FDAStringConverter extends AbstractStringConverter {
      */
     @Override
     public String toHtml(String str){
+        if (str.getBytes().length > 255) {
+            str = truncate(str, 254);
+        }
         return this.replaceFromLists(str, plainStrings, htmlStrings);
     }
 
@@ -69,6 +72,9 @@ public class FDAStringConverter extends AbstractStringConverter {
      */
     @Override
     public String toStd(String str){
+        if (str.getBytes().length > 255) {
+            str = truncate(str, 254);
+        }
         return this.replaceFromLists(str, plainStrings, stdStrings);
     }
 

--- a/app/ix/ginas/models/v1/Name.java
+++ b/app/ix/ginas/models/v1/Name.java
@@ -99,11 +99,11 @@ public class Name extends CommonDataElementOfCollection {
 
     @JsonProperty("_name_html")
     public String getHtmlName() {
-        return Util.getStringConverter().toHtml(name);
+        return Util.getStringConverter().toHtml(getName());
     }
 	@JsonProperty("_name")
 	public String getStandardName() {
-		return Util.getStringConverter().toStd(name);
+		return Util.getStringConverter().toStd(getName());
 	}
 
     public String getName () {
@@ -113,7 +113,7 @@ public class Name extends CommonDataElementOfCollection {
     @PostLoad
 	public void computeStdNameIfNeededOnLoad(){
     	if(stdName ==null && name !=null) {
-			stdName = Util.getStringConverter().toStd(name);
+			stdName = Util.getStringConverter().toStd(getName());
 		}
 	}
     @PrePersist
@@ -124,6 +124,8 @@ public class Name extends CommonDataElementOfCollection {
 			if (name.getBytes().length > 255) {
 				fullName = name;
 				name = Util.getStringConverter().truncate(name, 254);
+			}else{
+				fullName = null;
 			}
 		}
     }

--- a/app/ix/ginas/models/v1/Substance.java
+++ b/app/ix/ginas/models/v1/Substance.java
@@ -488,7 +488,7 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
 
         @Override
         public String apply(Name name) {
-            return Util.getStringConverter().toStd(name.name);
+            return name.getStandardName();
         }
     };
 


### PR DESCRIPTION
This PR will change output of getHtmlName and getStandartName methods, by using fullName if present (names will be displayed without truncation). The old behavior can be preserved by truncating of Names within toHtml and toStd methods of Converter class.