### PR TITLE
revertStdNameChange

### DIFF
--- a/app/ix/ginas/models/v1/Name.java
+++ b/app/ix/ginas/models/v1/Name.java
@@ -101,35 +101,30 @@ public class Name extends CommonDataElementOfCollection {
     public String getHtmlName() {
         return Util.getStringConverter().toHtml(getName());
     }
-	@JsonProperty("_name")
-	public String getStandardName() {
-		return Util.getStringConverter().toStd(getName());
-	}
+
+    @JsonProperty("_name")
+    public String getStandardName() {
+        if(stdName != null) {
+            return stdName;
+        }
+        return Util.getStringConverter().toStd(getName());
+    }
 
     public String getName () {
         return fullName != null ? fullName : name;
     }
 
-    @PostLoad
-	public void computeStdNameIfNeededOnLoad(){
-    	if(stdName ==null && name !=null) {
-			stdName = Util.getStringConverter().toStd(getName());
-		}
-	}
     @PrePersist
     @PreUpdate
     public void tidyName () {
-    	if(name !=null) {
-			stdName = Util.getStringConverter().toStd(name);
-			if (name.getBytes().length > 255) {
-				fullName = name;
-				name = Util.getStringConverter().truncate(name, 254);
-			}else{
-				fullName = null;
-			}
-		}
+        if(name != null) {
+            if (name.getBytes().length > 255) {
+                fullName = name;
+                name = Util.getStringConverter().truncate(name, 254);
+            }
+        }
     }
-    
+
     public void addLocator(Substance sub, String loc){
     	Reference r = new Reference();
     	r.docType=Name.SRS_LOCATOR;

--- a/modules/ginas/app/ix/ginas/processors/StdNameProcessor.java
+++ b/modules/ginas/app/ix/ginas/processors/StdNameProcessor.java
@@ -1,0 +1,18 @@
+package ix.ginas.processors;
+
+import ix.core.EntityProcessor;
+import ix.ginas.models.v1.Name;
+import ix.utils.Util;
+
+public class StdNameProcessor implements EntityProcessor<Name>{
+
+    @Override
+    public void prePersist(Name obj) {
+        obj.stdName = Util.getStringConverter().toStd(obj.getName());
+    }
+
+    @Override
+    public void preUpdate(Name obj) {
+        prePersist(obj);
+    }
+}


### PR DESCRIPTION
This PR reverted back usage of stdName fields. It must be filled separately from processor or initializer modules.