### PR TITLE
Fix html truncation

### DIFF
--- a/app/ix/ginas/models/converters/HTMLStringConverter.java
+++ b/app/ix/ginas/models/converters/HTMLStringConverter.java
@@ -102,7 +102,7 @@ public class HTMLStringConverter extends AbstractStringConverter {
         StringWriter writer = new StringWriter();
         Tidy tidy = TIDY_POOL.get();
         for(int i = maxBytes; i >= 0; i--){
-            if (badLastChars.contains(str.charAt(i-1))) {
+            if (i > 0 && badLastChars.contains(str.charAt(i-1))) {
                 continue;
             }
             tidy.parse(new StringReader("<html><head><title>Test</title></head><body>" + str.substring(0, i) + "</body></html>"), writer);

--- a/app/ix/ginas/models/v1/Relationship.java
+++ b/app/ix/ginas/models/v1/Relationship.java
@@ -171,7 +171,7 @@ public class Relationship extends CommonDataElementOfCollection {
     }
 
     public String toSimpleString(){
-    	return type + ":" + relatedSubstance.refPname;
+    	return type + ":" + relatedSubstance.getName();
     }
 
 	@Override

--- a/app/ix/ginas/models/v1/Substance.java
+++ b/app/ix/ginas/models/v1/Substance.java
@@ -457,11 +457,14 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
         return names.stream().min(Util.getComparatorFor(Name.class));
     }
 
-
+    @JsonIgnore
+    public String getName() {
+        return getFormattedName(NAME_FUNCTION);
+    }
 
     @JsonProperty("_name")
     @Indexable(suggest = true, name = "Display Name", sortable=true)
-    public String getName() {
+    public String getStandardName() {
         return getFormattedName(STDNAME_FUNCTION);
     }
     @JsonProperty("_nameHTML")
@@ -481,7 +484,7 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
 
         @Override
         public String apply(Name name) {
-            return name.name;
+            return name.getName();
         }
     };
     private static Function<Name, String > STDNAME_FUNCTION = new Function<Name, String>(){
@@ -501,7 +504,7 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
         if(this.isAlternativeDefinition()){
             SubstanceReference subref=this.getPrimaryDefinitionReference();
             if(subref!=null){
-                String name1=subref.getHtmlName();
+                String name1=nameFunction.apply(new Name(subref.refPname));
                 if(name1!=null){
                     return Substance.DEFAULT_ALTERNATIVE_NAME + " for [" + name1 + "]";
                 }
@@ -802,7 +805,7 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
      */
     public SubstanceReference asSubstanceReference(){
         SubstanceReference subref=new SubstanceReference();
-        subref.refPname=this.getName();
+        subref.refPname=this.getFormattedName(NAME_FUNCTION);
         subref.refuuid=this.getOrGenerateUUID().toString();
         subref.approvalID=this.approvalID;
         return subref;
@@ -978,7 +981,7 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
         if(uuid!=null){
             return uuid.toString();
         }
-        return getName();
+        return getStandardName();
     }
 
     @PreUpdate
@@ -1233,8 +1236,8 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
         if (approvalID != null) {
             c.setProperty("APPROVAL_ID", approvalID);
         }
-        c.setProperty("NAME", getName());
-        c.setName(getName());
+        c.setProperty("NAME", getStandardName());
+        c.setName(getStandardName());
         StringBuilder sb = new StringBuilder();
 
         for (Name n : getOfficialNames()) {

--- a/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
@@ -22,7 +22,7 @@
 
 @defining(CardViewPlugin.getInstance().getDetailCardsFor(sub)) {cards =>
 
-@ix.ginas.views.html.ginas(sub.getName, "ix.ginas.models.v1.Substance") {
+@ix.ginas.views.html.ginas(sub.getStandardName, "ix.ginas.models.v1.Substance") {
 @ix.ginas.views.html.menu()
 }{
 <div class ="fixedpos">


### PR DESCRIPTION
This PR will fix **truncate** function in **HTMLStringConverter** class.The **refPname** property of **SubstanceReference** class will be truncated before storing in DB. The **refPname** property will be stored in **RAW** format which can be converted in **Standard** or **HTML** format (o.e getFormattedName for Alternative definitions). The **getStandardName** function added to **Substance** class an used for creation of **_name** JSON properties. The **getName** function of **Substance** class will return **Display Name** in RAW format. The **Standard Name** will be used as Page Title for Substance details page.