### PR TITLE
FixHtmlNames

### DIFF
--- a/modules/ginas/app/assets/ginas/js/ginas-form-elements.js
+++ b/modules/ginas/app/assets/ginas/js/ginas-form-elements.js
@@ -825,13 +825,13 @@
                 var template;
                 if (scope.format == "subref") {
                     template = angular.element('<div>' +
-                        '<rendered id= {{ref.uuid}} size="200"></rendered><br/><code>{{ref._name}}</code><br/><code>{{ref.source}}</code><br>' +
+                        '<rendered id= {{ref.uuid}} size="200"></rendered><br/><code>{{ref._nameHTML}}</code><br/><code>{{ref.source}}</code><br>' +
                         '<button class = "btn btn-primary" ng-click="$parent.select(ref)">Select</button>' +
                         '</div>');
                 } else if (scope.ref.uuid) {
                     var url = baseurl + 'substance/' + scope.ref.uuid.split('-')[0];
                     template = angular.element('<div>' +
-                        '<rendered id = {{ref.uuid}} size="200"></rendered><br/><code>{{ref._name}}</code><br/><code>G-SRS Duplicate</code><br/>' +
+                        '<rendered id = {{ref.uuid}} size="200"></rendered><br/><code>{{ref._nameHTML}}</code><br/><code>G-SRS Duplicate</code><br/>' +
                         '<div class ="row"><div class="col-md-12"><button class = "btn btn-primary" ng-click="$parent.select(ref)">Apply Structure</button></div></div><br/>' +
                         '<div class="row"><div class="col-md-3 col-md-offset-3"><a class = "btn btn-primary" href = "' + url + '" target="_blank">View</a></div>' +
                         '<div class = "col-md-3"><a class = "btn btn-primary" href = "' + url + '/edit" target="_self">Edit</a></div>' +
@@ -840,7 +840,7 @@
                     template = angular.element('<div><code>No substances found</code></div>');
                 } else {
                     template = angular.element('<div>' +
-                        '<rendered id= {{ref.value.id}} size="200"></rendered><br/><code>{{ref._name}}</code><br/><code>{{ref.source}}</code><br>' +
+                        '<rendered id= {{ref.value.id}} size="200"></rendered><br/><code>{{ref._nameHTML}}</code><br/><code>{{ref.source}}</code><br>' +
                         '<button class = "btn btn-primary" ng-click="$parent.select(ref)">Apply Structure</button>' +
                         '</div>');
                 }
@@ -865,7 +865,7 @@
                 scope.createSubref = function (selectedItem) {
                     var temp = {};
                     temp.refuuid = selectedItem.uuid;
-                    temp.refPname = selectedItem._name;
+                    temp.refPname = selectedItem._nameHTML;
                     temp.approvalID = selectedItem.approvalID;
                     temp.substanceClass = "reference";
                     scope.subref = angular.copy(temp);
@@ -899,7 +899,7 @@
                 scope.createSubref = function (selectedItem) {
                     var subref = {};
                     subref.refuuid = selectedItem.uuid;
-                    subref.refPname = selectedItem._name;
+                    subref.refPname = selectedItem._nameHTML;
                     subref.approvalID = selectedItem.approvalID;
                     subref.substanceClass = "reference";
                     scope.obj[scope.field] = angular.copy(subref);
@@ -976,7 +976,7 @@
                 scope.createSubref = function (selectedItem) {
                     var temp = {};
                     temp.refuuid = selectedItem.uuid;
-                    temp.refPname = selectedItem._name;
+                    temp.refPname = selectedItem._nameHTML;
                     temp.approvalID = selectedItem.approvalID;
                     temp.substanceClass = "reference";
                     if (attrs.definition) {

--- a/modules/ginas/app/assets/ginas/js/ginas-form-elements.js
+++ b/modules/ginas/app/assets/ginas/js/ginas-form-elements.js
@@ -187,6 +187,7 @@
         	var n = name.replace("\"","");
         	//Needs sanitation
             var searchStr = "root_names_name:\"^" + n + "$\" OR " +
+                            "root_names_stdName:\"^" + n + "$\" OR " +
                             "root_approvalID:\"^" + n + "$\" OR " +
                             "root_codes_BDNUM:\"^" + n + "$\"";
 

--- a/modules/ginas/app/assets/ginas/js/ginasApp.js
+++ b/modules/ginas/app/assets/ginas/js/ginasApp.js
@@ -1021,7 +1021,7 @@
                 var namelist = [];
                 for (var i = 0; i < response.data.length; i++) {
                     if (response.data[i].type == 'sys') {
-                        namelist.push($sce.trustAsHtml(response.data[i]._name));
+                        namelist.push($sce.trustAsHtml(response.data[i]._nameHTML));
                     }
                 }
                 $scope.sysNames = namelist;

--- a/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
@@ -22,7 +22,7 @@
 
 @defining(CardViewPlugin.getInstance().getDetailCardsFor(sub)) {cards =>
 
-@ix.ginas.views.html.ginas(sub.getStandardName, "ix.ginas.models.v1.Substance") {
+@ix.ginas.views.html.ginas(sub.getName, "ix.ginas.models.v1.Substance") {
 @ix.ginas.views.html.menu()
 }{
 <div class ="fixedpos">

--- a/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/substancedetails.scala.html
@@ -22,7 +22,7 @@
 
 @defining(CardViewPlugin.getInstance().getDetailCardsFor(sub)) {cards =>
 
-@ix.ginas.views.html.ginas(sub.getName, "ix.ginas.models.v1.Substance") {
+@ix.ginas.views.html.ginas(sub.getStandardName, "ix.ginas.models.v1.Substance") {
 @ix.ginas.views.html.menu()
 }{
 <div class ="fixedpos">

--- a/modules/ginas/app/ix/ginas/views/list/commonlist.scala.html
+++ b/modules/ginas/app/ix/ginas/views/list/commonlist.scala.html
@@ -149,7 +149,7 @@
                                 aID = "PENDING RECORD";
                             }
                         }
-                        raw  += subref._name;
+                        raw  += subref._nameHTML;
                         if(i === 0){
                             dat1[i].state={selected:true};
                         }


### PR DESCRIPTION
This PR will fix problems related to usage of HTML formatted names.

- the name of attribute for HTML Names in SubstanceReference was changed from _name to _nameHTML.
- The Systematic Names of Structure will use HTML formatted names.
- stdName will be used for searchin of Related Substance in Substance editing form.