### PR TITLE
do not hide non-public substances on mixture parents card

### DIFF
--- a/modules/ginas/app/ix/ginas/views/details/properties/mixtureparents.scala.html
+++ b/modules/ginas/app/ix/ginas/views/details/properties/mixtureparents.scala.html
@@ -12,11 +12,9 @@
             <!-- <h5>The following mixtures contain this record:</h5>-->
         <div class = "row">
         @for(c <- parents) {
-            @if(c.isPublic()) {
-                <div class="col-md-3">
-                @subref(c.asSubstanceReference())
-                </div>
-            }
+            <div class="col-md-3">
+            @subref(c.asSubstanceReference())
+            </div>
         }
         </div>
     </div>


### PR DESCRIPTION
This PR reverted back the changes made to the mixtureparents.scala.html
 file by the 289639c5f85b1d52d75fc3a4aa7f4ba6d49ade40 commit, which prevents the displaying of non-public parent Mixtures.