### PR TITLE
CodeUpdaterScheduledJob

### DIFF
--- a/modules/ginas/app/ix/ginas/initializers/UpdateCodeTaskInitializer.java
+++ b/modules/ginas/app/ix/ginas/initializers/UpdateCodeTaskInitializer.java
@@ -1,0 +1,84 @@
+package ix.ginas.initializers;
+
+import ix.core.EntityProcessor;
+import ix.core.adapters.EntityPersistAdapter;
+import ix.core.factories.EntityProcessorFactory;
+import ix.core.models.Group;
+import ix.core.plugins.SchedulerPlugin.TaskListener;
+import ix.core.util.CachedSupplier;
+import ix.core.utils.executor.ProcessExecutionService;
+import ix.core.utils.executor.ProcessExecutionService.CommonStreamSuppliers;
+import ix.core.utils.executor.ProcessListener;
+import ix.ginas.models.v1.Code;
+import java.io.IOException;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import play.Play;
+
+/**
+ *
+ * @author Egor Puzanov
+ */
+
+public class UpdateCodeTaskInitializer extends ScheduledTaskInitializer {
+
+    private CachedSupplier<Set<EntityProcessor>> processors = CachedSupplier.of(()->
+            EntityProcessorFactory.getInstance(Play.application())
+                    .getRegisteredResourcesFor(Code.class));
+
+    @Override
+    public void run(TaskListener l) {
+        l.message("Initializing Code Updater");
+        ProcessListener listen = ProcessListener.onCountChange((sofar, total) -> {
+            if (total != null) {
+                l.message("Updated:" + sofar + " of " + total);
+            } else {
+                l.message("Updated:" + sofar);
+            }
+        });
+
+        try {
+            new ProcessExecutionService(5, 10).buildProcess(Code.class)
+                    .streamSupplier(CommonStreamSuppliers.allFor(Code.class))
+                    .consumer((Code c) -> {
+                        String comments = c.comments;
+                        c.comments = "";
+                        String url = c.url;
+                        c.url = "";
+                        Set<Group> access = c.getAccess();
+                        processors.get()
+                            .forEach(processor ->{
+                                try {
+                                    processor.preUpdate(c);
+                                } catch(Exception ex) {
+                                    Logger.getLogger(processor.getClass().getName()).log(Level.SEVERE, null, ex);
+                                }
+                            });
+                        if ((c.comments == null || c.comments.trim().isEmpty()) && !(comments == null || comments.trim().isEmpty())) {
+                            c.comments = comments;
+                        }
+                        if ((c.url == null || c.url.trim().isEmpty()) && !(url == null || url.trim().isEmpty())) {
+                            c.url = url;
+                        }
+                        if (!(comments == c.comments || (comments != null && c.comments != null && comments.equals(c.comments)))
+                                || !(url == c.url || (url != null && c.url != null && url.equals(c.url)))
+                                || !access.equals(c.getAccess())) {
+                            c.modified();
+                            c.forceUpdate();
+                            EntityPersistAdapter.getInstance().reindex(c);
+                        }
+                    })
+                    .listener(listen)
+                    .build()
+                    .execute();
+        } catch (IOException ex) {
+            Logger.getLogger(UpdateCodeTaskInitializer.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+
+    @Override
+    public String getDescription() {
+        return "Update all Codes in the database";
+    }
+}

--- a/modules/ginas/app/ix/ginas/processors/SetAccessCodeProcessor.java
+++ b/modules/ginas/app/ix/ginas/processors/SetAccessCodeProcessor.java
@@ -1,0 +1,90 @@
+package ix.ginas.processors;
+
+import ix.core.EntityProcessor;
+import ix.core.controllers.AdminFactory;
+import ix.core.models.Group;
+import ix.ginas.models.v1.Code;
+import ix.ginas.utils.GinasGlobal;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ *
+ * @author Egor Puzanov
+ */
+
+public class SetAccessCodeProcessor implements EntityProcessor<Code>{
+
+    public Map<String, Set<Group>> codeSystemAccess = new HashMap<String, Set<Group>>();
+
+    public SetAccessCodeProcessor(){
+        this(new HashMap<String, HashMap<String, List<String>>>());
+    }
+
+    public SetAccessCodeProcessor(Map m){
+        Runnable r = new Runnable(){
+            @Override
+            public void run(){
+                Map<String, List<String>> csa = Optional.ofNullable((Map<String, List<String>>) m.get("codeSystemAccess")).orElse(new HashMap<String, List<String>>());
+                csa.forEach((codeSystem, groups) -> {
+                    Set<Group> access = new LinkedHashSet<Group>();
+                    for ( String g : groups ) {
+                        access.add(AdminFactory.registerGroupIfAbsent(new Group(g)));
+                    }
+                    codeSystemAccess.put(codeSystem, access);
+                });
+            }
+        };
+        GinasGlobal.runAfterStart(r);
+    }
+
+    @Override
+    public void prePersist(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        Set<Group> defaultAccess = codeSystemAccess.get("*");
+        Set<Group> access = codeSystemAccess.getOrDefault(obj.codeSystem, defaultAccess);
+        if(access != null){
+            obj.setAccess(access);
+        }
+    }
+
+    @Override
+    public void postPersist(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void preRemove(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void postRemove(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void preUpdate(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        prePersist(obj);
+    }
+
+    @Override
+    public void postUpdate(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void postLoad(Code obj) throws ix.core.EntityProcessor.FailProcessingException {
+        // TODO Auto-generated method stub
+
+    }
+
+}

--- a/modules/ginas/conf/ginas.conf
+++ b/modules/ginas/conf/ginas.conf
@@ -363,6 +363,10 @@ ix.core.initializers=[
     # You can set the output path for the report, defaults to
     # reports directory with timestamp and date
     #"output.path" : "reports/orphanReferences-%DATE%-%TIME%.txt"
+  },
+  {
+    "class":"ix.ginas.initializers.UpdateCodeTaskInitializer",
+    "autorun":false
   }
   
 ]


### PR DESCRIPTION
This PR adds a new 'Update all Codes in the database' scheduled job, which runs all preUpdate processors for every Code in the database. So it makes possible to refresh 'url', 'comments' and 'access' attributes of all Codes.

Additionally this PR provides SetAccessCodeProcessor, which sets access for Code elements based on codeSystem.
Configuration Example (all Codes except BDNUM will be Public):
```
ix.core.entityprocessors += {
    "class":"ix.ginas.models.v1.Code",
    "processor":"ix.ginas.processors.SetAccessCodeProcessor",
    "with": {
        "codeSystemAccess": {
            "BDNUM": ["protected"],
            "*": []
        }
    }
}
```