### PR TITLE
configurableValidationNotes

### DIFF
--- a/app/ix/core/validator/GinasProcessingMessage.java
+++ b/app/ix/core/validator/GinasProcessingMessage.java
@@ -23,6 +23,7 @@ public class GinasProcessingMessage implements ValidationMessage {
 	}
 	public boolean suggestedChange=false;
 	public boolean appliedChange=false;
+	public boolean addAsNote=true;
 	public List<Link> links = new ArrayList<Link>();
 	
 	private boolean possibleDuplicate=false;
@@ -33,7 +34,12 @@ public class GinasProcessingMessage implements ValidationMessage {
 		this.messageType=mtype;
 		this.message=msg;
 	}
-	
+
+	public GinasProcessingMessage addNote(boolean b){
+		this.addAsNote=b;
+		return this;
+	}
+
 	public GinasProcessingMessage appliableChange(boolean b){
 		this.suggestedChange=b;
 		return this;

--- a/app/ix/ginas/models/v1/Substance.java
+++ b/app/ix/ginas/models/v1/Substance.java
@@ -1397,10 +1397,12 @@ public class Substance extends GinasCommonData implements ValidationMessageHolde
         boolean added = false;
 
         for(GinasProcessingMessage message: gpm){
-            Note n=this.addValidationNote(message, r);
-            if(n!=null){
-                n.addRestrictGroup(GROUP_ADMIN);
-                added = true;
+            if (message.addAsNote){
+                Note n=this.addValidationNote(message, r);
+                if(n!=null){
+                    n.addRestrictGroup(GROUP_ADMIN);
+                    added = true;
+                }
             }
         }
         if(!added){

--- a/modules/ginas/app/ix/ginas/utils/validation/validators/AbstractValidatorPlugin.java
+++ b/modules/ginas/app/ix/ginas/utils/validation/validators/AbstractValidatorPlugin.java
@@ -10,6 +10,8 @@ import ix.ginas.utils.validation.ValidatorPlugin;
  */
 public abstract class AbstractValidatorPlugin<T> implements ValidatorPlugin<T> {
 
+    public boolean addNote = true;
+
     @Override
     public boolean supports(T newValue, T oldValue, LoadValidatorInitializer.ValidatorConfig.METHOD_TYPE methodType) {
         if(methodType == LoadValidatorInitializer.ValidatorConfig.METHOD_TYPE.IGNORE){

--- a/modules/ginas/app/ix/ginas/utils/validation/validators/DefinitionalHashValidator.java
+++ b/modules/ginas/app/ix/ginas/utils/validation/validators/DefinitionalHashValidator.java
@@ -75,13 +75,15 @@ public class DefinitionalHashValidator  extends AbstractValidatorPlugin<Substanc
 												String message =
 													"WARNING! You have made a change to the fundamental definition of a validated substance. Are you sure you want to proceed with this change?";
 												callback.addMessage(GinasProcessingMessage
-													.WARNING_MESSAGE(message));
+													.WARNING_MESSAGE(message)
+													.addNote(this.addNote));
 												return;
 										}
 								}
 								String message= createDiffMessage(diff);
 								callback.addMessage(GinasProcessingMessage
-										.WARNING_MESSAGE(message));
+										.WARNING_MESSAGE(message)
+										.addNote(this.addNote));
 								Logger.trace("in DefinitionalHashValidator, apending message " + message);
 						} else {
 								Logger.trace("diffs empty ");

--- a/modules/ginas/app/ix/ginas/utils/validation/validators/SubstanceUniquenessValidator.java
+++ b/modules/ginas/app/ix/ginas/utils/validation/validators/SubstanceUniquenessValidator.java
@@ -50,7 +50,7 @@ public class SubstanceUniquenessValidator extends AbstractValidatorPlugin<Substa
 					mes= GinasProcessingMessage.WARNING_MESSAGE(messageText);
 				}
 				mes.addLink(GinasUtils.createSubstanceLink(possibleMatch));
-				callback.addMessage(mes);
+				callback.addMessage(mes.addNote(this.addNote));
 			}
 		}
 		else {
@@ -65,7 +65,7 @@ public class SubstanceUniquenessValidator extends AbstractValidatorPlugin<Substa
 					GinasProcessingMessage mes = GinasProcessingMessage.WARNING_MESSAGE(message);
 					Logger.debug("in SubstanceUniquenessValidator after message creation");
 					mes.addLink(GinasUtils.createSubstanceLink(possibleMatch));
-					callback.addMessage(mes);
+					callback.addMessage(mes.addNote(this.addNote));
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds a new 'addNote' boolean parameter to Validator Plugins. If this parameter is set to 'True' (by default), then validation notes will be added to the substance.
Example:

```
substance.validators += {
  "validatorClass" = "ix.ginas.utils.validation.validators.DefinitionalHashValidator",
  "newObjClass" = "ix.ginas.models.v1.Substance",
  "parameters" = {"addNote":false }
}
```